### PR TITLE
fix: deprecate job_arn request parameter

### DIFF
--- a/src/util/mrHelper.ts
+++ b/src/util/mrHelper.ts
@@ -22,7 +22,6 @@ import {
 export interface ImageRequest {
   jobId: string;
   jobName: string;
-  jobArn: string;
   imageUrls: string[];
   outputs: any[];
   imageProcessor: any;
@@ -272,7 +271,6 @@ function buildImageProcessingRequest(
   featureProperties: string
 ): ImageRequest {
   const jobName: string = `test_${jobId}`;
-  const jobArn: string = `arn:aws:oversightml:${REGION}:${ACCOUNT}:ipj/${jobName}`;
   const resultStream = `${KINESIS_RESULTS_STREAM_PREFIX}-${ACCOUNT}`;
   const resultBucket = `${S3_RESULTS_BUCKET_PREFIX}-${ACCOUNT}`;
   const processor = {
@@ -303,7 +301,6 @@ function buildImageProcessingRequest(
   const imageRequest: ImageRequest = {
     jobId: jobId,
     jobName: jobName,
-    jobArn: jobArn,
     imageUrls: [s3Uri],
     imageReadRole: imageReadRole,
     imageProcessor: processor,


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
- The "job_arn" parameter is redundant with "job_id" and therefore not needed. This will not break any changes.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
